### PR TITLE
Revert "Bump pillow from 5.4.1 to 8.1.1 in /serverless-src"

### DIFF
--- a/serverless-src/requirements.txt
+++ b/serverless-src/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.0.2
 numpy==1.15.4
-Pillow==8.1.1
+Pillow==5.4.1
 google_api_python_client==1.7.7


### PR DESCRIPTION
Reverts SBHacks2019/heart.io-backend#4